### PR TITLE
Emoji fix. Works only with patched libxft-bgra

### DIFF
--- a/drw.c
+++ b/drw.c
@@ -139,12 +139,12 @@ xfont_create(Drw *drw, const char *fontname, FcPattern *fontpattern)
 	 * https://lists.suckless.org/dev/1701/30932.html
 	 * https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=916349
 	 * and lots more all over the internet.
-	 */
+	 *
 	FcBool iscol;
 	if(FcPatternGetBool(xfont->pattern, FC_COLOR, 0, &iscol) == FcResultMatch && iscol) {
 		XftFontClose(drw->dpy, xfont);
 		return NULL;
-	}
+	}*/
 
 	font = ecalloc(1, sizeof(Fnt));
 	font->xfont = xfont;


### PR DESCRIPTION
Fix for proper emoji display in statusbar. Commented out the check for emoji which was disabling it to display and converting to outline version to prevent dwm crashing when trying to render colored emoji. 

This actually is not a dwm issue. The check was introduced due to a bug in libxft which caused crashes when rendering emojis with color. So this works with patched version (which is libxft-bgra) only (!)

**[INSTALL PATCHED LIBXFT-BGRA VERSION](https://aur.archlinux.org/packages/libxft-bgra/)**

Unpatched lib version will lead to crash once we try to render colored emoji.